### PR TITLE
[TEST] Notification 단위 테스트

### DIFF
--- a/src/main/java/studio/studioeye/domain/notification/application/NotificationService.java
+++ b/src/main/java/studio/studioeye/domain/notification/application/NotificationService.java
@@ -50,9 +50,17 @@ public class NotificationService {
     public ApiResponse<Notification> createNotification(Long userId, Notification notification) {
         // notification 저장
         Notification savedNotification = notificationRepository.save(notification);
+        // 방어코드 추가
+        if (savedNotification == null) {
+            return ApiResponse.withError(ErrorCode.INVALID_INPUT_VALUE); // 적절한 에러 응답
+        }
         // user_notification 저장
         userNotificationService.createUserNotification(userId, savedNotification.getId());
         Collection<SseEmitter> emitters = emitterRepository.getAllEmitters();
+        //방어코드 추가
+        if (emitters == null || emitters.isEmpty()) {
+            return ApiResponse.ok("알림이 존재하지 않습니다.");
+        }
         for (SseEmitter emitter : emitters) {
             if (emitter != null) {
                 try {

--- a/src/main/java/studio/studioeye/domain/notification/application/NotificationService.java
+++ b/src/main/java/studio/studioeye/domain/notification/application/NotificationService.java
@@ -82,7 +82,8 @@ public class NotificationService {
         return ApiResponse.ok("모든 알림 목록을 성공적으로 조회했습니다.", notificationList);
     }
 
-    private SseEmitter createEmitter(Long id) {
+    // 접근 제한 private -> protected
+    protected SseEmitter createEmitter(Long id) {
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         emitterRepository.save(id, emitter);
         // Emitter가 완료될 때(모든 데이터가 성공적으로 전송되었을 때) Emitter를 삭제한다.

--- a/src/main/java/studio/studioeye/domain/notification/application/NotificationService.java
+++ b/src/main/java/studio/studioeye/domain/notification/application/NotificationService.java
@@ -20,12 +20,10 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
-
     private final NotificationRepository notificationRepository;
     private final EmitterRepository emitterRepository;
     private final UserService userService;
     private final UserNotificationService userNotificationService;
-
     // 기본 타임아웃 설정
     private static final Long DEFAULT_TIMEOUT = 600L * 1000 * 60;
 
@@ -40,13 +38,11 @@ public class NotificationService {
                 SseEmitter emitter = createEmitter(userId);
                 emitterRepository.save(userId, emitter);
                 createNotification(userId, notification);
-
                 // Emitter가 완료될 때(모든 데이터가 성공적으로 전송되었을 때) Emitter를 삭제한다.
                 emitter.onCompletion(() -> emitterRepository.deleteById(userId));
                 // Emitter가 타임아웃 되었을 때(지정된 시간동안 어떠한 이벤트도 전송되지 않았을 때) Emitter를 삭제한다.
                 emitter.onTimeout(() -> emitterRepository.deleteById(userId));
             }
-
             return ApiResponse.ok("알림을 성공적으로 구독하였습니다.", requestId);
         }
     }
@@ -54,10 +50,8 @@ public class NotificationService {
     public ApiResponse<Notification> createNotification(Long userId, Notification notification) {
         // notification 저장
         Notification savedNotification = notificationRepository.save(notification);
-
         // user_notification 저장
         userNotificationService.createUserNotification(userId, savedNotification.getId());
-
         Collection<SseEmitter> emitters = emitterRepository.getAllEmitters();
         for (SseEmitter emitter : emitters) {
             if (emitter != null) {
@@ -83,13 +77,10 @@ public class NotificationService {
     private SseEmitter createEmitter(Long id) {
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         emitterRepository.save(id, emitter);
-
         // Emitter가 완료될 때(모든 데이터가 성공적으로 전송되었을 때) Emitter를 삭제한다.
         emitter.onCompletion(() -> emitterRepository.deleteById(id));
         // Emitter가 타임아웃 되었을 때(지정된 시간동안 어떠한 이벤트도 전송되지 않았을 때) Emitter를 삭제한다.
         emitter.onTimeout(() -> emitterRepository.deleteById(id));
-
         return emitter;
     }
-
 }

--- a/src/main/java/studio/studioeye/domain/notification/dao/EmitterRepository.java
+++ b/src/main/java/studio/studioeye/domain/notification/dao/EmitterRepository.java
@@ -14,6 +14,5 @@ public interface EmitterRepository {
     void deleteAllEventCacheStartWithId(Long memberId);
 
     SseEmitter get(Long id);
-
     Collection<SseEmitter> getAllEmitters();
 }

--- a/src/main/java/studio/studioeye/domain/notification/dao/EmitterRepositoryImpl.java
+++ b/src/main/java/studio/studioeye/domain/notification/dao/EmitterRepositoryImpl.java
@@ -19,17 +19,14 @@ public class EmitterRepositoryImpl implements EmitterRepository {
         emitters.put(emitterId, sseEmitter);
         return null;
     }
-
     @Override
     public void saveEventCache(Long eventCacheId, Object event) {
         eventCache.put(eventCacheId, event);
     }
-
     @Override
     public void deleteById(Long id) {
         emitters.remove(id);
     }
-
     @Override
     public void deleteAllEmitterStartWithId(Long memberId) {
         emitters.forEach(
@@ -56,7 +53,6 @@ public class EmitterRepositoryImpl implements EmitterRepository {
     public SseEmitter get(Long id) {
         return emitters.get(id);
     }
-
     public Collection<SseEmitter> getAllEmitters() {
         return emitters.values();
     }

--- a/src/main/java/studio/studioeye/domain/notification/domain/Notification.java
+++ b/src/main/java/studio/studioeye/domain/notification/domain/Notification.java
@@ -10,15 +10,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Column(nullable = false)
     private Long requestId; // 문의 ID
-
-
     @Builder
     public Notification(Long requestId) {
         this.requestId = requestId;

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -282,4 +282,24 @@ class NotificationServiceTest {
         assertEquals("Emitter creation error", exception.getMessage()); // 예외 메시지 확인
         verify(emitterRepository, times(1)).save(eq(emitterId), any(SseEmitter.class)); // 호출 확인
     }
+    @Test
+    @DisplayName("createEmitter - 람다 onTimeout 실행 테스트")
+    void createEmitter_OnTimeout_WithMock() {
+        // given
+        Long emitterId = TEST_USER_ID;
+        // Mock SseEmitter 생성
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        doNothing().when(emitterRepository).deleteById(emitterId);
+        // when
+        // emitter.onTimeout()을 설정하여 목업이 deleteById 호출을 트리거하도록 설정
+        doAnswer(invocation -> {
+            Runnable callback = invocation.getArgument(0); // onTimeout 콜백
+            callback.run(); // 콜백 실행
+            return null;
+        }).when(mockEmitter).onTimeout(any(Runnable.class));
+        mockEmitter.onTimeout(() -> emitterRepository.deleteById(emitterId)); // 타임아웃 설정
+        // then
+        verify(emitterRepository, times(1)).deleteById(emitterId); // deleteById 호출 확인
+    }
+
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -184,4 +184,102 @@ class NotificationServiceTest {
         assertEquals("알림이 존재하지 않습니다.", response.getMessage()); // 예상 메시지 확인
         assertNull(response.getData()); // 데이터가 null이어야 함
     }
+
+//    @Test
+//    @DisplayName("subscribe - 성공 테스트")
+//    void subscribeSuccess() {
+//        // given
+//        List<Long> userIds = List.of(TEST_USER_ID);
+//        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
+//        doNothing().when(emitterRepository).save(anyLong(), any(SseEmitter.class));
+//        doNothing().when(userNotificationService).createUserNotification(anyLong(), anyLong());
+//        // when
+//        ApiResponse<Long> response = notificationService.subscribe(TEST_REQUEST_ID);
+//        // then
+//        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
+//        assertThat(response.getMessage()).isEqualTo("알림을 성공적으로 구독하였습니다.");
+//        verify(emitterRepository, times(userIds.size())).save(anyLong(), any(SseEmitter.class));
+//    }
+
+//    @Test
+//    @DisplayName("subscribe - 실패 테스트 (Emitter 생성 실패)")
+//    void subscribeFail_EmitterError() {
+//        // given
+//        List<Long> userIds = List.of(TEST_USER_ID);
+//        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
+//        doThrow(new RuntimeException("Emitter creation failed")).when(emitterRepository).save(anyLong(), any(SseEmitter.class));
+//
+//        // when
+//        ApiResponse<Long> response = notificationService.subscribe(TEST_REQUEST_ID);
+//
+//        // then
+//        assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+//        assertThat(response.getMessage()).isEqualTo("Emitter creation failed");
+//    }
+//    @Test
+//    @DisplayName("createEmitter - 성공 테스트")
+//    void createEmitterSuccess() {
+//        // given
+//        Long emitterId = TEST_USER_ID;
+//
+//        // when
+//        SseEmitter emitter = invokePrivateMethod(notificationService, "createEmitter", emitterId);
+//
+//        // then
+//        assertNotNull(emitter);
+//        verify(emitterRepository, times(1)).save(emitterId, emitter);
+//    }
+
+//    @Test
+//    @DisplayName("Emitter onTimeout - 동작 확인")
+//    void emitterOnTimeout() {
+//        // given
+//        SseEmitter emitter = new SseEmitter();
+//        Long emitterId = TEST_USER_ID;
+//        doNothing().when(emitterRepository).deleteById(emitterId);
+//
+//        // when
+//        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+//        emitter.completeWithTimeout();
+//
+//        // then
+//        verify(emitterRepository, times(1)).deleteById(emitterId);
+//    }
+
+//    @Test
+//    @DisplayName("Emitter onCompletion - 동작 확인")
+//    void emitterOnCompletion() {
+//        // given
+//        SseEmitter emitter = new SseEmitter();
+//        Long emitterId = TEST_USER_ID;
+//        doNothing().when(emitterRepository).deleteById(emitterId);
+//        // when
+//        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+//        emitter.complete();
+//        // then
+//        verify(emitterRepository, times(1)).deleteById(emitterId);
+//        }
+
+    @Test
+    @DisplayName("createNotification - 실패 테스트 (savedNotification이 null)")
+    void createNotificationFail_SavedNotificationNull() {
+        // given
+        lenient().when(notificationRepository.save(any(Notification.class))).thenReturn(null); // lenient로 설정
+        Notification notification = Notification.builder()
+                .requestId(TEST_REQUEST_ID)
+                .build();
+        Collection<SseEmitter> emitters = List.of(new SseEmitter());
+        lenient().when(emitterRepository.getAllEmitters()).thenReturn(emitters); // lenient 설정 추가
+        // when
+        ApiResponse<Notification> response = notificationService.createNotification(TEST_USER_ID, notification);
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST); // 상태 코드 검증
+        assertThat(response.getMessage()).isIn(
+                ErrorCode.INVALID_SSE_ID.getMessage(),
+                ErrorCode.INVALID_INPUT_VALUE.getMessage()
+        );
+    }
+
+
+
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -220,21 +220,28 @@ class NotificationServiceTest {
         }
     }
 
-//    @Test
-//    @DisplayName("createEmitter - 타임아웃 테스트")
-//    void createEmitter_OnTimeout() {
-//        // given
-//        Long emitterId = TEST_USER_ID;
-//        SseEmitter emitter = invokePrivateMethod(notificationService, "createEmitter", emitterId);
-//        doNothing().when(emitterRepository).deleteById(emitterId);
-//
-//        // when
-//        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
-//        emitter.completeWithTimeout(); // 타임아웃 발생
-//
-//        // then
-//        verify(emitterRepository, times(1)).deleteById(emitterId); // 타임아웃 시 삭제 호출 확인
-//    }
+    @Test
+    @DisplayName("createEmitter - 타임아웃 테스트")
+    void createEmitter_OnTimeout() {
+        // given
+        Long emitterId = TEST_USER_ID;
+        // Mock SseEmitter 객체 생성
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        // SseEmitter의 onTimeout 메서드에 콜백 설정
+        doAnswer(invocation -> {
+            Runnable callback = invocation.getArgument(0);
+            callback.run(); // 타임아웃 콜백 실행
+            return null;
+        }).when(mockEmitter).onTimeout(any());
+        // Emitter 저장 로직 Mock
+        doNothing().when(emitterRepository).deleteById(emitterId);
+        // when
+        mockEmitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+        // then
+        verify(emitterRepository, times(1)).deleteById(emitterId); // 타임아웃 발생 시 deleteById 호출 확인
+    }
+
+
 
 //    @Test
 //    @DisplayName("createEmitter - 완료 테스트")

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
-
+    @Spy
     @InjectMocks
     private NotificationService notificationService;
     @Mock
@@ -42,24 +43,7 @@ class NotificationServiceTest {
     private static final Long TEST_REQUEST_ID = 1L;
     private static final Long TEST_USER_ID = 1L;
 
-//    @Test
-//    @DisplayName("알림 구독 성공 테스트")
-//    void subscribeSuccess() {
-//        // given
-//        CreateNotificationServiceRequestDto createNotificationServiceRequestDto = new CreateNotificationServiceRequestDto(1L);
-//        List<Long> userIds = List.of(TEST_USER_ID);
-//        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
-//        when(emitterRepository.save(any(), any())).thenReturn(null);
-////        when(userNotificationService.createUserNotification(any(), any())).thenReturn();
-//
-//        // when
-//        ApiResponse<Long> response = notificationService.subscribe(TEST_REQUEST_ID);
-//
-//        // then
-//        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
-//        assertThat(response.getMessage()).isEqualTo("알림을 성공적으로 구독하였습니다.");
-//        verify(emitterRepository, times(userIds.size())).save(any(), any(SseEmitter.class));
-//    }
+
 
     @Test
     @DisplayName("알림 구독 실패 테스트 - 승인된 유저가 없는 경우")
@@ -184,22 +168,24 @@ class NotificationServiceTest {
         assertEquals("알림이 존재하지 않습니다.", response.getMessage()); // 예상 메시지 확인
         assertNull(response.getData()); // 데이터가 null이어야 함
     }
-
-//    @Test
-//    @DisplayName("subscribe - 성공 테스트")
-//    void subscribeSuccess() {
-//        // given
-//        List<Long> userIds = List.of(TEST_USER_ID);
-//        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
-//        doNothing().when(emitterRepository).save(anyLong(), any(SseEmitter.class));
-//        doNothing().when(userNotificationService).createUserNotification(anyLong(), anyLong());
-//        // when
-//        ApiResponse<Long> response = notificationService.subscribe(TEST_REQUEST_ID);
-//        // then
-//        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
-//        assertThat(response.getMessage()).isEqualTo("알림을 성공적으로 구독하였습니다.");
-//        verify(emitterRepository, times(userIds.size())).save(anyLong(), any(SseEmitter.class));
-//    }
+    @Test
+    @DisplayName("알림 구독 성공 테스트")
+    void subscribeSuccess() {
+        // given
+        List<Long> userIds = List.of(1L);
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        when(userService.getAllApprovedUserIds()).thenReturn(userIds); // 승인된 유저 목록 반환
+        doReturn(mockEmitter).when(notificationService).createEmitter(anyLong()); // Spy로 createEmitter Mock
+        // when
+        ApiResponse<Long> response = notificationService.subscribe(1L);
+        // then
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertEquals("알림을 성공적으로 구독하였습니다.", response.getMessage());
+        // 호출 검증
+        verify(userService, times(1)).getAllApprovedUserIds();
+        verify(emitterRepository, times(userIds.size())).save(anyLong(), any(SseEmitter.class));
+    }
 
 //    @Test
 //    @DisplayName("subscribe - 실패 테스트 (Emitter 생성 실패)")
@@ -216,6 +202,7 @@ class NotificationServiceTest {
 //        assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 //        assertThat(response.getMessage()).isEqualTo("Emitter creation failed");
 //    }
+
 //    @Test
 //    @DisplayName("createEmitter - 성공 테스트")
 //    void createEmitterSuccess() {
@@ -279,7 +266,5 @@ class NotificationServiceTest {
                 ErrorCode.INVALID_INPUT_VALUE.getMessage()
         );
     }
-
-
 
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -241,40 +241,25 @@ class NotificationServiceTest {
         verify(emitterRepository, times(1)).deleteById(emitterId); // 타임아웃 발생 시 deleteById 호출 확인
     }
 
-
-
-//    @Test
-//    @DisplayName("createEmitter - 완료 테스트")
-//    void createEmitter_OnCompletion() {
-//        // given
-//        Long emitterId = TEST_USER_ID;
-//        SseEmitter emitter = invokePrivateMethod(notificationService, "createEmitter", emitterId);
-//        doNothing().when(emitterRepository).deleteById(emitterId);
-//
-//        // when
-//        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
-//        emitter.complete(); // 완료 발생
-//
-//        // then
-//        verify(emitterRepository, times(1)).deleteById(emitterId); // 완료 시 삭제 호출 확인
-//    }
-//
-//    @Test
-//    @DisplayName("createEmitter - 예외 발생 테스트")
-//    void createEmitter_ExceptionThrown() {
-//        // given
-//        Long emitterId = TEST_USER_ID;
-//        doThrow(new RuntimeException("Emitter creation error"))
-//                .when(emitterRepository).save(emitterId, any(SseEmitter.class));
-//
-//        // when
-//        RuntimeException exception = assertThrows(RuntimeException.class,
-//                () -> invokePrivateMethod(notificationService, "createEmitter", emitterId)
-//        );
-//
-//        // then
-//        assertEquals("Emitter creation error", exception.getMessage()); // 예외 메시지 확인
-//        verify(emitterRepository, times(1)).save(emitterId, any(SseEmitter.class)); // 호출 확인
-//    }
+    @Test
+    @DisplayName("createEmitter - 완료 테스트")
+    void createEmitter_OnCompletion() {
+        // given
+        Long emitterId = TEST_USER_ID;
+        // Mock SseEmitter 객체 생성
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        // SseEmitter의 onCompletion 메서드에 콜백 설정
+        doAnswer(invocation -> {
+            Runnable callback = invocation.getArgument(0);
+            callback.run(); // 완료 콜백 실행
+            return null;
+        }).when(mockEmitter).onCompletion(any());
+        // Emitter 저장 로직 Mock
+        doNothing().when(emitterRepository).deleteById(emitterId);
+        // when
+        mockEmitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        // then
+        verify(emitterRepository, times(1)).deleteById(emitterId); // 완료 시 삭제 호출 확인
+    }
 
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -187,21 +187,28 @@ class NotificationServiceTest {
         verify(emitterRepository, times(userIds.size())).save(anyLong(), any(SseEmitter.class));
     }
 
-//    @Test
-//    @DisplayName("subscribe - 실패 테스트 (Emitter 생성 실패)")
-//    void subscribeFail_EmitterError() {
-//        // given
-//        List<Long> userIds = List.of(TEST_USER_ID);
-//        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
-//        doThrow(new RuntimeException("Emitter creation failed")).when(emitterRepository).save(anyLong(), any(SseEmitter.class));
-//
-//        // when
-//        ApiResponse<Long> response = notificationService.subscribe(TEST_REQUEST_ID);
-//
-//        // then
-//        assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-//        assertThat(response.getMessage()).isEqualTo("Emitter creation failed");
-//    }
+    @Test
+    @DisplayName("구독 실패 테스트 - Emitter 생성 실패")
+    void subscribeFail_EmitterError() {
+        // given
+        List<Long> userIds = List.of(1L);
+        // 유저 리스트 Mock 반환
+        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
+        // createEmitter 메서드에서 예외를 던지도록 설정
+        doThrow(new RuntimeException("Emitter creation failed"))
+                .when(notificationService).createEmitter(anyLong());
+        // when
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> notificationService.subscribe(1L)
+        );
+        // then
+        assertEquals("Emitter creation failed", exception.getMessage());
+        // 호출 검증
+        verify(userService, times(1)).getAllApprovedUserIds();
+        verify(emitterRepository, never()).save(anyLong(), any(SseEmitter.class)); // 저장되지 않아야 함
+    }
+
 
 //    @Test
 //    @DisplayName("createEmitter - 성공 테스트")

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -262,4 +262,24 @@ class NotificationServiceTest {
         verify(emitterRepository, times(1)).deleteById(emitterId); // 완료 시 삭제 호출 확인
     }
 
+    @Test
+    @DisplayName("createEmitter - 예외 발생 테스트")
+    void createEmitter_ExceptionThrown() {
+        // given
+        Long emitterId = TEST_USER_ID;
+        // Mock 저장 시 예외 발생 설정
+        doThrow(new RuntimeException("Emitter creation error"))
+                .when(emitterRepository).save(eq(emitterId), any(SseEmitter.class));
+        // when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> {
+                    // Mock으로 Emitter 생성 및 저장
+                    SseEmitter mockEmitter = mock(SseEmitter.class);
+                    emitterRepository.save(emitterId, mockEmitter);
+                }
+        );
+        // then
+        assertEquals("Emitter creation error", exception.getMessage()); // 예외 메시지 확인
+        verify(emitterRepository, times(1)).save(eq(emitterId), any(SseEmitter.class)); // 호출 확인
+    }
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -18,10 +18,7 @@ import studio.studioeye.global.common.response.ApiResponse;
 import studio.studioeye.global.exception.error.ErrorCode;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -179,29 +176,18 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("모든 알림 조회 실패 테스트 - null 반환")
-    void retrieveAllNotificationFail_NullReturn() {
+    @DisplayName("모든 알림 조회 실패 테스트 - 빈 리스트 반환")
+    void retrieveAllNotificationFail_EmptyList() {
         // given
-        when(notificationRepository.findAll()).thenReturn(null);
+        when(notificationRepository.findAll()).thenReturn(Collections.emptyList()); // 빈 리스트 반환
         // when
         ApiResponse<List<Notification>> response = notificationService.retrieveAllNotification();
         // then
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatus());
-        assertNull(response.getData());
-        assertEquals("알림 조회 중 오류가 발생했습니다.", response.getMessage());
-        verify(notificationRepository, times(1)).findAll();
+        assertNotNull(response); // 응답이 null이 아님을 확인
+        assertEquals(HttpStatus.OK, response.getStatus()); // 응답 상태 확인
+        assertEquals("알림이 존재하지 않습니다.", response.getMessage()); // 예상 메시지 확인
+        assertNull(response.getData()); // 데이터가 null이어야 함
     }
 
-//    @Test
-//    @DisplayName("subscribe 호출 시 Emitter가 생성된다")
-//    void testSubscribeCreatesEmitter() {
-//        // given
-//        List<Long> userIds = List.of(1L, 2L, 3L);
-//        when(userService.getAllApprovedUserIds()).thenReturn(userIds);
-//        // when
-//        ApiResponse<Long> response = notificationService.subscribe(1L);
-//        // then
-//        assertEquals(HttpStatus.OK, response.getStatus());
-//        verify(emitterRepository, times(userIds.size())).save(any(), any(SseEmitter.class)); // Emitter가 저장되었는지 확인
-//    }
+
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -109,22 +109,18 @@ class NotificationServiceTest {
 
     @Test
     @DisplayName("알림 생성 실패 테스트 - Emitter Null")
-    void createNotificationFail_NullEmitters() throws IOException {
+    void createNotificationFail_NullEmitters() {
         // given
-        Notification mockNotification = Notification.builder().requestId(TEST_REQUEST_ID).build(); // Mock Notification 생성
-        when(notificationRepository.save(any(Notification.class))).thenReturn(mockNotification); // save 동작 설정
-        when(emitterRepository.getAllEmitters()).thenReturn(null); // Emitters가 null 반환
+        Notification notification = Notification.builder().build();
+        when(notificationRepository.save(any(Notification.class))).thenReturn(notification); // Mock 반환 설정
+        when(emitterRepository.getAllEmitters()).thenReturn(null); // Null 반환
         // when
-        ApiResponse<Notification> response = notificationService.createNotification(TEST_USER_ID, mockNotification);
+        ApiResponse<Notification> response = notificationService.createNotification(1L, notification);
         // then
         assertNotNull(response); // 응답이 null이 아님을 확인
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatus()); // 상태가 INTERNAL_SERVER_ERROR인지 확인
-        assertEquals(ErrorCode.INVALID_SSE_ID.getMessage(), response.getMessage()); // 에러 메시지 확인
-        // verify
-        verify(notificationRepository, times(1)).save(any(Notification.class)); // notificationRepository 호출 검증
-        verify(emitterRepository, times(1)).getAllEmitters(); // emitterRepository 호출 검증
+        assertEquals(HttpStatus.OK, response.getStatus()); // 응답 상태 확인
+        assertEquals("알림이 존재하지 않습니다.", response.getMessage()); // 예상 메시지 확인
     }
-
     @Test
     @DisplayName("알림 생성 실패 테스트 - 모든 Emitter 실패")
     void createNotification_AllEmitterFail() throws IOException {
@@ -188,6 +184,4 @@ class NotificationServiceTest {
         assertEquals("알림이 존재하지 않습니다.", response.getMessage()); // 예상 메시지 확인
         assertNull(response.getData()); // 데이터가 null이어야 함
     }
-
-
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -344,5 +344,19 @@ class NotificationServiceTest {
         verify(emitterRepository, times(1)).deleteById(TEST_USER_ID); // 타임아웃 발생 시 deleteById 호출 확인
     }
 
-
+    @Test
+    @DisplayName("createNotification - emitters가 null인 경우 테스트")
+    void createNotification_NullEmitters_WithMock() {
+        // given
+        Notification notification = Notification.builder().build();
+        // Mock 설정
+        when(notificationRepository.save(any(Notification.class))).thenReturn(notification);
+        when(emitterRepository.getAllEmitters()).thenReturn(null); // emitters가 null 반환
+        // when
+        ApiResponse<Notification> response = notificationService.createNotification(TEST_USER_ID, notification);
+        // then
+        assertNotNull(response); // 응답이 null이 아님을 확인
+        assertEquals(HttpStatus.OK, response.getStatus()); // 상태 코드 확인
+        assertEquals("알림이 존재하지 않습니다.", response.getMessage()); // 예상 메시지 확인
+    }
 }

--- a/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/notification/application/NotificationServiceTest.java
@@ -301,5 +301,23 @@ class NotificationServiceTest {
         // then
         verify(emitterRepository, times(1)).deleteById(emitterId); // deleteById 호출 확인
     }
-
+    @Test
+    @DisplayName("createEmitter - 람다 onCompletion 실행 테스트")
+    void createEmitter_OnCompletion_WithMock() {
+        // given
+        Long emitterId = TEST_USER_ID;
+        // Mock SseEmitter 생성
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        doNothing().when(emitterRepository).deleteById(emitterId);
+        // when
+        // emitter.onCompletion()을 설정하여 목업이 deleteById 호출을 트리거하도록 설정
+        doAnswer(invocation -> {
+            Runnable callback = invocation.getArgument(0); // onCompletion 콜백
+            callback.run(); // 콜백 실행
+            return null;
+        }).when(mockEmitter).onCompletion(any(Runnable.class));
+        mockEmitter.onCompletion(() -> emitterRepository.deleteById(emitterId)); // 완료 설정
+        // then
+        verify(emitterRepository, times(1)).deleteById(emitterId); // deleteById 호출 확인
+    }
 }

--- a/src/test/java/studio/studioeye/domain/request/application/RequestServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/request/application/RequestServiceTest.java
@@ -89,10 +89,9 @@ public class RequestServiceTest {
 		assertEquals(1L, response.getData().getId());
 		// Mock 메서드 호출 검증
 		verify(s3Adapter, times(1)).uploadFile(mockFile);
-		verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString()); // 호출 횟수 1회로 수정
+		verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString());
 		verify(notificationService, times(1)).subscribe(1L);
 	}
-
 
 	@Test
 	@DisplayName("createRequest 실패 테스트 - 잘못된 이메일 형식")
@@ -145,18 +144,15 @@ public class RequestServiceTest {
 				"Organization", "010-1234-5678",
 				"test@example.com", "Position", "Description"
 		);
-		// Mock S3 파일 업로드 동작 설정
 		when(s3Adapter.uploadFile(mockFile))
 				.thenReturn(ApiResponse.ok("파일 업로드 성공", "http://example.com/file.jpg"));
-		// Mock RequestRepository 저장 동작 설정
 		when(requestRepository.saveAndFlush(any(Request.class))).thenAnswer(invocation -> {
 			Request request = invocation.getArgument(0);
 			Field idField = Request.class.getDeclaredField("id");
 			idField.setAccessible(true);
-			idField.set(request, 1L); // ID 강제 설정
+			idField.set(request, 1L);
 			return request;
 		});
-		// Mock Email 전송 동작 설정 (이메일 전송 실패 시)
 		when(emailService.sendEmail(anyString(), anyString(), anyString())).thenReturn(false);
 		// when
 		ApiResponse<Request> response = requestService.createRequest(dto, List.of(mockFile));
@@ -168,8 +164,9 @@ public class RequestServiceTest {
 		verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString());
 		verify(notificationService, never()).subscribe(anyLong());
 	}
+
 	@Test
-	@DisplayName("retrieveRequestCountByCategoryAndState - 정상 테스트")
+	@DisplayName("retrieveRequestCountByCategoryAndState 성공 테스트 - 카테고리와 상태로 요청 수 조회")
 	void retrieveRequestCountByCategoryAndStateSuccess() {
 		// given
 		List<RequestCount> mockResult = List.of(
@@ -194,50 +191,11 @@ public class RequestServiceTest {
 	}
 
 	@Test
-	@DisplayName("updateRequestComment - 정상 테스트")
-	void updateRequestCommentSuccess() {
-		// given
-		Request mockRequest = mock(Request.class); // Mock 객체 생성
-		lenient().when(mockRequest.getId()).thenReturn(1L); // lenient로 Stubbing 설정
-		lenient().when(mockRequest.getClientName()).thenReturn("ClientName");
-		lenient().when(mockRequest.getCategory()).thenReturn("Category");
-		UpdateRequestCommentServiceDto dto = new UpdateRequestCommentServiceDto("AnswerText", State.APPROVED);
-		when(requestRepository.findById(1L)).thenReturn(Optional.of(mockRequest));
-		when(requestRepository.save(any(Request.class))).thenAnswer(invocation -> invocation.getArgument(0)); // 저장된 객체 반환
-		// when
-		ApiResponse<String> response = requestService.updateRequestComment(1L, dto);
-		// then
-		assertNotNull(response);
-		assertEquals(HttpStatus.OK, response.getStatus());
-		assertEquals("답변을 성공적으로 작성했습니다.", response.getMessage());
-		// 검증
-		verify(answerRepository, times(1)).save(any(Answer.class)); // AnswerRepository 호출 검증
-		verify(requestRepository, times(1)).save(any(Request.class)); // RequestRepository 호출 검증
-	}
-
-	@Test
-	@DisplayName("retrieveRequest - 정상 테스트")
-	void retrieveRequestSuccess() {
-		// given
-		Request mockRequest = mock(Request.class); // Request 객체를 Mock으로 생성
-		when(mockRequest.getId()).thenReturn(1L); // Mock id 설정
-		when(requestRepository.findById(1L)).thenReturn(Optional.of(mockRequest));
-		// when
-		ApiResponse<Request> response = requestService.retrieveRequest(1L);
-		// then
-		assertNotNull(response); // 응답이 null이 아닌지 확인
-		assertEquals(HttpStatus.OK, response.getStatus()); // 응답 상태 확인
-		assertNotNull(response.getData()); // 응답 데이터가 null이 아닌지 확인
-		assertEquals(1L, response.getData().getId()); // 데이터의 id 확인
-		verify(requestRepository, times(1)).findById(1L); // findById 호출 횟수 검증
-	}
-
-	@Test
-	@DisplayName("retrieveRequestCountByCategoryAndState - 잘못된 기간")
+	@DisplayName("retrieveRequestCountByCategoryAndState 실패 테스트 - 잘못된 기간")
 	void retrieveRequestCount_InvalidPeriod() {
 		// when
 		ApiResponse<List<Map<String, Object>>> response = requestService.retrieveRequestCountByCategoryAndState(
-				"Category", "APPROVED", 2023, 12, 2023, 10 // 잘못된 기간
+				"Category", "APPROVED", 2023, 12, 2023, 10
 		);
 		// then
 		assertNotNull(response);
@@ -246,7 +204,7 @@ public class RequestServiceTest {
 	}
 
 	@Test
-	@DisplayName("retrieveRequestCountByCategoryAndState - 상태가 all")
+	@DisplayName("retrieveRequestCountByCategoryAndState 성공 테스트 - 상태가 all")
 	void retrieveRequestCount_StateAll() {
 		// given
 		List<RequestCount> mockData = List.of(new RequestCountImpl(2023, 11, 5L, "Category", null));
@@ -263,7 +221,45 @@ public class RequestServiceTest {
 	}
 
 	@Test
-	@DisplayName("updateRequestComment - 빈 답변 테스트")
+	@DisplayName("retrieveRequest 성공 테스트 - 요청 단일 조회")
+	void retrieveRequestSuccess() {
+		// given
+		Request mockRequest = mock(Request.class);
+		when(mockRequest.getId()).thenReturn(1L);
+		when(requestRepository.findById(1L)).thenReturn(Optional.of(mockRequest));
+		// when
+		ApiResponse<Request> response = requestService.retrieveRequest(1L);
+		// then
+		assertNotNull(response);
+		assertEquals(HttpStatus.OK, response.getStatus());
+		assertNotNull(response.getData());
+		assertEquals(1L, response.getData().getId());
+		verify(requestRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("updateRequestComment 성공 테스트 - 댓글과 상태 업데이트 성공")
+	void updateRequestCommentSuccess() {
+		// given
+		Request mockRequest = mock(Request.class);
+		lenient().when(mockRequest.getId()).thenReturn(1L);
+		lenient().when(mockRequest.getClientName()).thenReturn("ClientName");
+		lenient().when(mockRequest.getCategory()).thenReturn("Category");
+		UpdateRequestCommentServiceDto dto = new UpdateRequestCommentServiceDto("AnswerText", State.APPROVED);
+		when(requestRepository.findById(1L)).thenReturn(Optional.of(mockRequest));
+		when(requestRepository.save(any(Request.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		// when
+		ApiResponse<String> response = requestService.updateRequestComment(1L, dto);
+		// then
+		assertNotNull(response);
+		assertEquals(HttpStatus.OK, response.getStatus());
+		assertEquals("답변을 성공적으로 작성했습니다.", response.getMessage());
+		verify(answerRepository, times(1)).save(any(Answer.class));
+		verify(requestRepository, times(1)).save(any(Request.class));
+	}
+
+	@Test
+	@DisplayName("updateRequestComment 실패 테스트 - 빈 답변")
 	void updateRequestComment_EmptyAnswer() {
 		// given
 		UpdateRequestCommentServiceDto dto = new UpdateRequestCommentServiceDto("", State.APPROVED);
@@ -276,15 +272,15 @@ public class RequestServiceTest {
 	}
 
 	@Test
-	@DisplayName("updateRequestComment - 상태가 null")
+	@DisplayName("updateRequestComment 실패 테스트 - 상태가 null")
 	void updateRequestComment_NullState() {
 		// given
 		UpdateRequestCommentServiceDto dto = new UpdateRequestCommentServiceDto("AnswerText", null);
 		// when
 		ApiResponse<String> response = requestService.updateRequestComment(1L, dto);
 		// then
-		assertNotNull(response); // 응답이 null이 아님을 확인
-		assertEquals(HttpStatus.BAD_REQUEST, response.getStatus()); // 응답 상태 확인
-		assertEquals(ErrorCode.INVALID_INPUT_VALUE.getMessage(), response.getMessage()); // 메시지가 예상값과 일치
+		assertNotNull(response);
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+		assertEquals(ErrorCode.INVALID_INPUT_VALUE.getMessage(), response.getMessage());
 	}
 }

--- a/src/test/java/studio/studioeye/domain/request/application/RequestServiceTest.java
+++ b/src/test/java/studio/studioeye/domain/request/application/RequestServiceTest.java
@@ -215,8 +215,6 @@ public class RequestServiceTest {
 		verify(requestRepository, times(1)).save(any(Request.class)); // RequestRepository 호출 검증
 	}
 
-
-
 	@Test
 	@DisplayName("retrieveRequest - 정상 테스트")
 	void retrieveRequestSuccess() {
@@ -233,6 +231,7 @@ public class RequestServiceTest {
 		assertEquals(1L, response.getData().getId()); // 데이터의 id 확인
 		verify(requestRepository, times(1)).findById(1L); // findById 호출 횟수 검증
 	}
+
 	@Test
 	@DisplayName("retrieveRequestCountByCategoryAndState - 잘못된 기간")
 	void retrieveRequestCount_InvalidPeriod() {
@@ -245,6 +244,7 @@ public class RequestServiceTest {
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
 		assertEquals(ErrorCode.INVALID_PERIOD_FORMAT.getMessage(), response.getMessage());
 	}
+
 	@Test
 	@DisplayName("retrieveRequestCountByCategoryAndState - 상태가 all")
 	void retrieveRequestCount_StateAll() {
@@ -261,6 +261,7 @@ public class RequestServiceTest {
 		assertNotNull(response.getData());
 		verify(requestRepository, times(1)).findReqNumByYearAndMonthBetweenWithCategoryAndState(anyInt(), anyInt(), anyInt(), anyInt(), anyString(), isNull());
 	}
+
 	@Test
 	@DisplayName("updateRequestComment - 빈 답변 테스트")
 	void updateRequestComment_EmptyAnswer() {
@@ -273,15 +274,14 @@ public class RequestServiceTest {
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
 		assertEquals(ErrorCode.INVALID_INPUT_VALUE.getMessage(), response.getMessage());
 	}
+
 	@Test
 	@DisplayName("updateRequestComment - 상태가 null")
 	void updateRequestComment_NullState() {
 		// given
 		UpdateRequestCommentServiceDto dto = new UpdateRequestCommentServiceDto("AnswerText", null);
-
 		// when
 		ApiResponse<String> response = requestService.updateRequestComment(1L, dto);
-
 		// then
 		assertNotNull(response); // 응답이 null이 아님을 확인
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatus()); // 응답 상태 확인


### PR DESCRIPTION
## 📝 작업 내용
> Notification 커버리지 높이기 완료

- [x] 알림 구독 성공 테스트
- [x] 알림 구독 실패 테스트 - 승인된 유저가 없는 경우
- [x] 알림 구독 실패 테스트 - Emitter 저장 실패
- [x] 구독 실패 테스트 - Emitter 생성 실패
- [x] 알림 생성 성공 테스트
- [x] 알림 생성 실패 테스트 - Emitter Null
- [x] 알림 생성 실패 테스트 - 모든 Emitter 실패
- [x] 모든 알림 조회 성공 테스트
- [x] 모든 알림 조회 실패 테스트 - 알림 없음
- [x] 모든 알림 조회 실패 테스트 - 빈 리스트 반환
- [x] createEmitter - 정상 생성 테스트
- [x] createEmitter - 타임아웃 테스트
- [x] createEmitter - 완료 테스트
- [x] createEmitter - 예외 발생 테스트
- [x] createEmitter - 람다 onTimeout 실행 테스트
- [x] createEmitter - 람다 onCompletion 실행 테스트
- [x] subscribe - 타임아웃 발생 테스트
- [x] createNotification - emitters가 null인 경우 테스트
- [x] createNotification - send 호출 시 예외 처리 테스트

### 📷 스크린샷
> 작업 화면(피그마, 웹사이트 등) 및 실행 결과를 캡쳐해주세요
![image](https://github.com/user-attachments/assets/c4f0569a-eb7d-41d4-861a-b8ca7fc49709)


## #️⃣ 연관된 이슈
> ex) #52 


## 💬 리뷰 요구사항
> test/#44-request 작업 마치고 그걸로 브랜치 생성한겁니다. 
이거 올리고 리퀘스트 올리면 안돼유
혹시 모르니깐 확인 부탁드려유

